### PR TITLE
Admin disables merchant

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -1,0 +1,6 @@
+class Admin::MerchantsController < ApplicationController
+
+  def index
+    @merchants = Merchant.all
+  end
+end

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -3,4 +3,10 @@ class Admin::MerchantsController < ApplicationController
   def index
     @merchants = Merchant.all
   end
+
+  def disable
+    @merchant = Merchant.find(params[:merchant_id])
+    @merchant.update(active?: false)
+    redirect_to "/admin/merchants"
+  end
 end

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -8,5 +8,6 @@ class Admin::MerchantsController < ApplicationController
     @merchant = Merchant.find(params[:merchant_id])
     @merchant.update(active?: false)
     redirect_to "/admin/merchants"
+    flash[:notice] = "#{@merchant.name} is disabled"
   end
 end

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -1,0 +1,15 @@
+
+
+<h1>Admin Merchant Index Page</h1>
+
+<h2>Merchants</h2>
+
+<% @merchants.each do |merchant| %>
+  <section id= <%= "merchant-#{merchant.id}" %>>
+    <h3><%= merchant.name %></h3>
+    <p><%= "#{merchant.city}, #{merchant.state}" %></p>
+
+    <p><%= button_to "Disable" %></p>
+    <p><%= button_to "Enable" %></p>
+  </section>
+<% end %>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -9,6 +9,10 @@
     <h3><%= merchant.name %></h3>
     <p><%= "#{merchant.city}, #{merchant.state}" %></p>
 
-    <p><%= button_to "Disable" %></p>
+    <% if merchant.active? == true %>
+      <p><%= button_to "Disable", "/admin/merchants/#{merchant.id}/disable", method: :patch %></p>
+    <% else %>
+      <p><%= button_to "Enable", "/admin/merchants/#{merchant.id}/enable", method: :patch %></p>
+    <% end %>
   </section>
 <% end %>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -10,6 +10,5 @@
     <p><%= "#{merchant.city}, #{merchant.state}" %></p>
 
     <p><%= button_to "Disable" %></p>
-    <p><%= button_to "Enable" %></p>
   </section>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,5 +65,6 @@ Rails.application.routes.draw do
   namespace :admin do
     get "/", to: "dashboard#index"
     get "/users", to: "dashboard#users"
+    get "/merchants", to: "merchants#index"
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,5 +66,6 @@ Rails.application.routes.draw do
     get "/", to: "dashboard#index"
     get "/users", to: "dashboard#users"
     get "/merchants", to: "merchants#index"
+    patch "/merchants/:merchant_id/disable", to: "merchants#disable"
   end
 end

--- a/db/migrate/20201103181701_add_active_to_merchants.rb
+++ b/db/migrate/20201103181701_add_active_to_merchants.rb
@@ -1,0 +1,5 @@
+class AddActiveToMerchants < ActiveRecord::Migration[5.2]
+  def change
+    add_column :merchants, :active?, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 2020_11_03_181701) do
     t.integer "quantity"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status", default: 0
     t.index ["item_id"], name: "index_item_orders_on_item_id"
     t.index ["order_id"], name: "index_item_orders_on_order_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_03_031721) do
+ActiveRecord::Schema.define(version: 2020_11_03_181701) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,6 +47,7 @@ ActiveRecord::Schema.define(version: 2020_11_03_031721) do
     t.integer "zip"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "active?", default: true
   end
 
   create_table "orders", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema.define(version: 2020_11_03_031721) do
 
   # These are extensions that must be enabled in order to support this database
@@ -23,7 +22,6 @@ ActiveRecord::Schema.define(version: 2020_11_03_031721) do
     t.integer "quantity"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "status", default: 0
     t.index ["item_id"], name: "index_item_orders_on_item_id"
     t.index ["order_id"], name: "index_item_orders_on_order_id"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,6 +13,8 @@ Item.destroy_all
 #merchants
 bike_shop = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
 dog_shop = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80210)
+fishing_shop = Merchant.create(name: "Tim's Fishing Store", address: '127 Fish It Dr.', city: 'Denver', state: 'CO', zip: 80205)
+cookie_shop = Merchant.create(name: "Alex's Cookies and Treats", address: '128 Chip Ave.', city: 'Denver', state: 'CO', zip: 80211)
 
 #bike_shop items
 tire = bike_shop.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -9,51 +9,57 @@
 
 require 'rails_helper'
 
-RSpec.describe "As an Admin visiting my Admin's Merchant Index page" do
-  before(:each) do
-    @bike_shop = Merchant.create!(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
-    @dog_shop = Merchant.create!(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80210)
-    @fishing_shop = Merchant.create!(name: "Tim's Fishing Store", address: '127 Fish It Dr.', city: 'Denver', state: 'CO', zip: 80205)
-    @cookie_shop = Merchant.create!(name: "Alex's Cookies and Treats", address: '128 Chip Ave.', city: 'Denver', state: 'CO', zip: 80211)
-  end
+RSpec.describe "As an Admin" do
+  describe "When I visit my Admin's Merchant Index page" do
+    before(:each) do
+      @bike_shop = Merchant.create!(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+      @dog_shop = Merchant.create!(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80210)
+      @fishing_shop = Merchant.create!(name: "Tim's Fishing Store", address: '127 Fish It Dr.', city: 'Denver', state: 'CO', zip: 80205)
+      @cookie_shop = Merchant.create!(name: "Alex's Cookies and Treats", address: '128 Chip Ave.', city: 'Denver', state: 'CO', zip: 80211)
+    end
 
-  it "I see a 'disable' button next to any merchants not disabled" do
+    it "I see a 'Disable' button next to any merchants not disabled" do
 
-    visit "/admin/merchants"
+      visit "/admin/merchants"
 
-      within "#merchant-#{@bike_shop.id}" do
-        expect(page).to have_button("Disable")
-        expect(page).to_not have_button("Enable")
-      end
+        within "#merchant-#{@bike_shop.id}" do
+          expect(page).to have_button("Disable")
+          expect(page).to_not have_button("Enable")
+        end
 
-      within "#merchant-#{@dog_shop.id}" do
-        expect(page).to have_button("Disable")
-        expect(page).to_not have_button("Enable")
-      end
+        within "#merchant-#{@dog_shop.id}" do
+          expect(page).to have_button("Disable")
+          expect(page).to_not have_button("Enable")
+        end
 
-      within "#merchant-#{@fishing_shop.id}" do
-        expect(page).to have_button("Disable")
-        expect(page).to_not have_button("Enable")
-      end
+        within "#merchant-#{@fishing_shop.id}" do
+          expect(page).to have_button("Disable")
+          expect(page).to_not have_button("Enable")
+        end
 
-      within "#merchant-#{@cookie_shop.id}" do
-        expect(page).to have_button("Disable")
-        expect(page).to_not have_button("Enable")
-      end
-  end
+        within "#merchant-#{@cookie_shop.id}" do
+          expect(page).to have_button("Disable")
+          expect(page).to_not have_button("Enable")
+        end
+    end
 
-  it "When I click 'disable' I'm returned to '/admin/merchants' and that merchant is now disabled" do
+    it "When I click 'Disable' I'm returned to '/admin/merchants' and that merchant is now disabled" do
 
-    visit "/admin/merchants"
+      visit "/admin/merchants"
 
-      within "#merchant-#{@bike_shop.id}" do
-        click_link "disable"
-      end
-    expect(current_path).to eq("admin/merchants")
+        within "#merchant-#{@bike_shop.id}" do
+          click_button "Disable"
+        end
 
+      expect(current_path).to eq("/admin/merchants")
 
-  end
+        within "#merchant-#{@bike_shop.id}" do
+          expect(page).to_not have_button("Disable")
+          expect(page).to have_button("Enable")
+        end
+    end
 
-  it "I see a flash message that the merchant's account is now disabled" do
+    it "I see a flash message that the merchant's account is now disabled" do
+    end
   end
 end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -1,12 +1,3 @@
-# User Story 38, Admin disables a merchant account
-#
-# As an admin
-# When I visit the admin's merchant index page ('/admin/merchants')
-# I see a "disable" button next to any merchants who are not yet disabled
-# When I click on the "disable" button
-# I am returned to the admin's merchant index page where I see that the merchant's account is now disabled
-# And I see a flash message that the merchant's account is now disabled
-
 require 'rails_helper'
 
 RSpec.describe "As an Admin" do
@@ -60,6 +51,15 @@ RSpec.describe "As an Admin" do
     end
 
     it "I see a flash message that the merchant's account is now disabled" do
+
+      visit "/admin/merchants"
+
+      within "#merchant-#{@dog_shop.id}" do
+        click_button "Disable"
+      end
+
+      expect(current_path).to eq("/admin/merchants")
+      expect(page).to have_content("#{@dog_shop.name} is disabled")
     end
   end
 end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -23,26 +23,35 @@ RSpec.describe "As an Admin visiting my Admin's Merchant Index page" do
 
       within "#merchant-#{@bike_shop.id}" do
         expect(page).to have_button("Disable")
-        expect(page).to have_button("Enable")
+        expect(page).to_not have_button("Enable")
       end
 
       within "#merchant-#{@dog_shop.id}" do
         expect(page).to have_button("Disable")
-        expect(page).to have_button("Enable")
+        expect(page).to_not have_button("Enable")
       end
 
       within "#merchant-#{@fishing_shop.id}" do
         expect(page).to have_button("Disable")
-        expect(page).to have_button("Enable")
+        expect(page).to_not have_button("Enable")
       end
 
       within "#merchant-#{@cookie_shop.id}" do
         expect(page).to have_button("Disable")
-        expect(page).to have_button("Enable")
+        expect(page).to_not have_button("Enable")
       end
   end
 
   it "When I click 'disable' I'm returned to '/admin/merchants' and that merchant is now disabled" do
+
+    visit "/admin/merchants"
+
+      within "#merchant-#{@bike_shop.id}" do
+        click_link "disable"
+      end
+    expect(current_path).to eq("admin/merchants")
+
+
   end
 
   it "I see a flash message that the merchant's account is now disabled" do

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -1,0 +1,51 @@
+# User Story 38, Admin disables a merchant account
+#
+# As an admin
+# When I visit the admin's merchant index page ('/admin/merchants')
+# I see a "disable" button next to any merchants who are not yet disabled
+# When I click on the "disable" button
+# I am returned to the admin's merchant index page where I see that the merchant's account is now disabled
+# And I see a flash message that the merchant's account is now disabled
+
+require 'rails_helper'
+
+RSpec.describe "As an Admin visiting my Admin's Merchant Index page" do
+  before(:each) do
+    @bike_shop = Merchant.create!(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+    @dog_shop = Merchant.create!(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80210)
+    @fishing_shop = Merchant.create!(name: "Tim's Fishing Store", address: '127 Fish It Dr.', city: 'Denver', state: 'CO', zip: 80205)
+    @cookie_shop = Merchant.create!(name: "Alex's Cookies and Treats", address: '128 Chip Ave.', city: 'Denver', state: 'CO', zip: 80211)
+  end
+
+  it "I see a 'disable' button next to any merchants not disabled" do
+    @cookie_shop.update_attribute(:active?, false)
+
+    visit "/admin/merchants"
+
+      within "#merchant-#{@bike_shop.id}" do
+        expect(page).to have_button("Disable")
+        expect(page).to have_button("Enable")
+      end
+
+      within "#merchant-#{@dog_shop.id}" do
+        expect(page).to have_button("Disable")
+        expect(page).to have_button("Enable")
+      end
+
+      within "#merchant-#{@fishing_shop.id}" do
+        expect(page).to have_button("Disable")
+        expect(page).to have_button("Enable")
+      end
+
+      within "#merchant-#{@cookie_shop.id}" do
+        expect(page).to_not have_button("Disable")
+        expect(page).to have_button("Enable")
+      end
+  end
+
+  it "When I click 'disable' I'm returned to '/admin/merchants' and that merchant is now disabled" do
+  end
+
+  it "I see a flash message that the merchant's account is now disabled" do
+  end
+end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe "As an Admin visiting my Admin's Merchant Index page" do
   end
 
   it "I see a 'disable' button next to any merchants not disabled" do
-    @cookie_shop.update_attribute(:active?, false)
 
     visit "/admin/merchants"
 
@@ -38,7 +37,7 @@ RSpec.describe "As an Admin visiting my Admin's Merchant Index page" do
       end
 
       within "#merchant-#{@cookie_shop.id}" do
-        expect(page).to_not have_button("Disable")
+        expect(page).to have_button("Disable")
         expect(page).to have_button("Enable")
       end
   end


### PR DESCRIPTION
This PR:

- creates an `Admin::MerchantsController`
- [x] We should discuss if we would rather have an `Admin::DashboardController`

- creates 2 new routes in the `namespace :admin` block
   - `get "/merchants", to: "merchants#index"` and `patch "/merchants/:merchant_id/disable", to: "merchants#disable"`
- [x] there are a couple other ways we could have done this, which we can talk about

- adds functionality for an Admin to disable merchants on an `Admin Merchants Index Page`

- closes #38 
