### PR TITLE
Disabled merchant inactive items

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -7,6 +7,7 @@ class Admin::MerchantsController < ApplicationController
   def disable
     @merchant = Merchant.find(params[:merchant_id])
     @merchant.update(active?: false)
+    @merchant.items.update(active?: false)
     redirect_to "/admin/merchants"
     flash[:notice] = "#{@merchant.name} is disabled"
   end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -1,3 +1,10 @@
+# User Story 39, Disabled Merchant Item's are inactive
+#
+# As an admin
+# When I visit the merchant index page
+# And I click on the "disable" button for an enabled merchant
+# Then all of that merchant's items should be deactivated
+
 require 'rails_helper'
 
 RSpec.describe "As an Admin" do
@@ -7,6 +14,14 @@ RSpec.describe "As an Admin" do
       @dog_shop = Merchant.create!(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80210)
       @fishing_shop = Merchant.create!(name: "Tim's Fishing Store", address: '127 Fish It Dr.', city: 'Denver', state: 'CO', zip: 80205)
       @cookie_shop = Merchant.create!(name: "Alex's Cookies and Treats", address: '128 Chip Ave.', city: 'Denver', state: 'CO', zip: 80211)
+
+      @tire = bike_shop.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
+      @bell = bike_shop.items.create(name: "Silver Bell", description: "Let everyone know you're coming!", price: 25, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 10)
+      @kickstand = bike_shop.items.create(name: "Kickstand", description: "Don't fall!", price: 75, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 4)
+
+      @spring = dog_shop.items.create(name: "Spring Toy", description: "Best thing to chase", price: 7, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", inventory: 53)
+      @leash = dog_shop.items.create(name: "Leash", description: "Walk that dog!", price: 15, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", inventory: 41)
+      @octopus = dog_shop.items.create(name: "Plush Octopus Toy", description: "Your dog will love this thing", price: 32, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", inventory: 12)
     end
 
     it "I see a 'Disable' button next to any merchants not disabled" do
@@ -60,6 +75,30 @@ RSpec.describe "As an Admin" do
 
       expect(current_path).to eq("/admin/merchants")
       expect(page).to have_content("#{@dog_shop.name} is disabled")
+    end
+
+    it "I click on 'Disable' for a specific merchant and all their items are deactivated" do
+
+      visit "/admin/merchants"
+
+      within ".merchant-#{@bike_shop.id}" do
+      click_button "Disable"
+      expect(current_path).to eq("/admin/merchants")
+      expect(page).to_not have_link("Disable")
+      expect(page).to have_link("Enable")
+    end
+
+      visit "/items/#{@bell.id}"
+      expect(page).to have_content("Inactive")
+
+      visit "/items/#{@kickstand.id}"
+      expect(page).to have_content("Inactive")
+
+      visit "/items/#{@tire.id}"
+      expect(page).to have_content("Inactive")
+
+      visit "/items/#{@spring.id}"
+      expect(page).to have_content("Active")
     end
   end
 end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -1,10 +1,3 @@
-# User Story 39, Disabled Merchant Item's are inactive
-#
-# As an admin
-# When I visit the merchant index page
-# And I click on the "disable" button for an enabled merchant
-# Then all of that merchant's items should be deactivated
-
 require 'rails_helper'
 
 RSpec.describe "As an Admin" do
@@ -15,13 +8,13 @@ RSpec.describe "As an Admin" do
       @fishing_shop = Merchant.create!(name: "Tim's Fishing Store", address: '127 Fish It Dr.', city: 'Denver', state: 'CO', zip: 80205)
       @cookie_shop = Merchant.create!(name: "Alex's Cookies and Treats", address: '128 Chip Ave.', city: 'Denver', state: 'CO', zip: 80211)
 
-      @tire = bike_shop.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
-      @bell = bike_shop.items.create(name: "Silver Bell", description: "Let everyone know you're coming!", price: 25, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 10)
-      @kickstand = bike_shop.items.create(name: "Kickstand", description: "Don't fall!", price: 75, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 4)
+      @tire = @bike_shop.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
+      @bell = @bike_shop.items.create(name: "Silver Bell", description: "Let everyone know you're coming!", price: 25, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 10)
+      @kickstand = @bike_shop.items.create(name: "Kickstand", description: "Don't fall!", price: 75, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 4)
 
-      @spring = dog_shop.items.create(name: "Spring Toy", description: "Best thing to chase", price: 7, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", inventory: 53)
-      @leash = dog_shop.items.create(name: "Leash", description: "Walk that dog!", price: 15, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", inventory: 41)
-      @octopus = dog_shop.items.create(name: "Plush Octopus Toy", description: "Your dog will love this thing", price: 32, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", inventory: 12)
+      @spring = @dog_shop.items.create(name: "Spring Toy", description: "Best thing to chase", price: 7, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", inventory: 53)
+      @leash = @dog_shop.items.create(name: "Leash", description: "Walk that dog!", price: 15, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", inventory: 41)
+      @octopus = @dog_shop.items.create(name: "Plush Octopus Toy", description: "Your dog will love this thing", price: 32, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", inventory: 12)
     end
 
     it "I see a 'Disable' button next to any merchants not disabled" do
@@ -77,16 +70,16 @@ RSpec.describe "As an Admin" do
       expect(page).to have_content("#{@dog_shop.name} is disabled")
     end
 
-    it "I click on 'Disable' for a specific merchant and all their items are deactivated" do
+    it "I click on 'Disable' button for a specific merchant and all their items are deactivated" do
 
       visit "/admin/merchants"
 
-      within ".merchant-#{@bike_shop.id}" do
-      click_button "Disable"
-      expect(current_path).to eq("/admin/merchants")
-      expect(page).to_not have_link("Disable")
-      expect(page).to have_link("Enable")
-    end
+        within "#merchant-#{@bike_shop.id}" do
+          click_button "Disable"
+          expect(current_path).to eq("/admin/merchants")
+          expect(page).to_not have_button("Disable")
+          expect(page).to have_button("Enable")
+        end
 
       visit "/items/#{@bell.id}"
       expect(page).to have_content("Inactive")


### PR DESCRIPTION
This PR:

- makes it so an Admin can disable a merchant, and then all that merchant's items are deactivated.
- closes #39 

I used ActiveRecord to add this line of code in the `disable` method on the `Admin::MerchantsController`:
```
@merchant.items.update(active?: false)
```
Technically that is logic that belongs in the model, but since it's only one line, I thought we could refactor later if we wanted...