### PR TITLE
Admin sees all orders

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,8 @@
+class Admin::BaseController < ApplicationController
+  before_action :require_admin
+
+  private
+  def require_admin
+    render file: "/public/404" unless current_admin?
+  end
+end

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,9 +1,9 @@
 class Admin::DashboardController < Admin::BaseController
   def index
-    @orders = Order.all
+    @orders = Order.status_sorted
   end
 
   def users
-
+    
   end
 end

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,6 +1,4 @@
-class Admin::DashboardController < ApplicationController
-  before_action :require_admin
-
+class Admin::DashboardController < Admin::BaseController
   def index
     @orders = Order.all
   end
@@ -8,9 +6,4 @@ class Admin::DashboardController < ApplicationController
   def users
 
   end
-
-  private
-    def require_admin
-      render file: "/public/404" unless current_admin?
-    end
 end

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -2,6 +2,7 @@ class Admin::DashboardController < ApplicationController
   before_action :require_admin
 
   def index
+    @orders = Order.all
   end
 
   def users

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -1,4 +1,4 @@
-class Admin::MerchantsController < ApplicationController
+class Admin::MerchantsController < Admin::BaseController
 
   def index
     @merchants = Merchant.all

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,12 @@
+class Admin::UsersController < ApplicationController
+  before_action :require_admin
+
+  def show
+
+  end
+
+  private
+  def require_admin
+    render file: "/public/404" unless current_admin?
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,12 +1,5 @@
-class Admin::UsersController < ApplicationController
-  before_action :require_admin
-
+class Admin::UsersController < Admin::BaseController
   def show
 
-  end
-
-  private
-  def require_admin
-    render file: "/public/404" unless current_admin?
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -3,6 +3,7 @@ class Order <ApplicationRecord
 
   has_many :item_orders
   has_many :items, through: :item_orders
+  belongs_to :user
 
   def grandtotal
     item_orders.sum('price * quantity')

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -19,7 +19,7 @@ class Order <ApplicationRecord
     item_orders.all? { |item_order| item_order.status == "fulfilled" }
   end
 
-  # def self.status_sorted
-  #   require 'pry' ; binding.pry
-  # end
+  def self.status_sorted
+    order(:status)
+  end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -5,6 +5,8 @@ class Order <ApplicationRecord
   has_many :items, through: :item_orders
   belongs_to :user
 
+  enum status: %w(Packaged Pending Shipped Cancelled)
+
   def grandtotal
     item_orders.sum('price * quantity')
   end
@@ -16,4 +18,8 @@ class Order <ApplicationRecord
   def all_fulfilled?
     item_orders.all? { |item_order| item_order.status == "fulfilled" }
   end
+
+  # def self.status_sorted
+  #   require 'pry' ; binding.pry
+  # end
 end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -7,6 +7,8 @@
       <%= content_tag :p do %>
         <%= "Order ID: #{order.id}" %>
         <%= content_tag :br %>
+        <%= "Status: #{order.status}" %>
+        <%= content_tag :br %>
         <%= "Created On: #{order.created_at.to_date}" %>
         <%= content_tag :br %>
         <%= "Users: " %><%= link_to order.name, "admin/users/#{order.user_id}" %>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,1 +1,9 @@
 <%= content_tag :h1, "Welcome #{current_user.name}!" %>
+
+<%= content_tag :ul, id: 'all-orders' do %>
+  <% @orders.each do |order| %>
+    <%= content_tag :li, id: "order-#{order.id}" do %>
+      <%=content_tag :p, "User: #{link_to(order.user.name, "some path")}" %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,9 +1,16 @@
 <%= content_tag :h1, "Welcome #{current_user.name}!" %>
 
 <%= content_tag :ul, id: 'all-orders' do %>
+  <%= content_tag :h3, "Orders:" %>
   <% @orders.each do |order| %>
     <%= content_tag :li, id: "order-#{order.id}" do %>
-      <%=content_tag :p, "User: #{link_to(order.user.name, "some path")}" %>
+      <%= content_tag :p do %>
+        <%= "Order ID: #{order.id}" %>
+        <%= content_tag :br %>
+        <%= "Created On: #{order.created_at.to_date}" %>
+        <%= content_tag :br %>
+        <%= "Users: " %><%= link_to order.name, "admin/users/#{order.user_id}" %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,5 +65,6 @@ Rails.application.routes.draw do
   namespace :admin do
     get "/", to: "dashboard#index"
     get "/users", to: "dashboard#users"
+    get "/users/:id", to: "users#show"
   end
 end

--- a/db/migrate/20201104002858_remove_status_from_orders.rb
+++ b/db/migrate/20201104002858_remove_status_from_orders.rb
@@ -1,0 +1,5 @@
+class RemoveStatusFromOrders < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :orders, :status, :string
+  end
+end

--- a/db/migrate/20201104003039_add_int_status_to_orders.rb
+++ b/db/migrate/20201104003039_add_int_status_to_orders.rb
@@ -1,0 +1,5 @@
+class AddIntStatusToOrders < ActiveRecord::Migration[5.2]
+  def change
+    add_column :orders, :status, :integer, default: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_03_031721) do
+ActiveRecord::Schema.define(version: 2020_11_04_003039) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,7 +59,7 @@ ActiveRecord::Schema.define(version: 2020_11_03_031721) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"
-    t.string "status", default: "Pending"
+    t.integer "status", default: 1
     t.index ["user_id"], name: "index_orders_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema.define(version: 2020_11_03_031721) do
 
   # These are extensions that must be enabled in order to support this database

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -42,11 +42,14 @@ tim = User.create!(name: 'Tim Tyrell', address: '421 Branch St.', city: 'Denver'
 
 # orders
 
-order1 = kiera.orders.create!(name: kiera.name, address: kiera.address, city: kiera.city, state: kiera.state, zip: kiera.zip)
+order1 = kiera.orders.create!(name: kiera.name, address: kiera.address, city: kiera.city, state: kiera.state, zip: kiera.zip, status: "Packaged")
 order1.item_orders.create!([{ item: tire, quantity: 2, price: tire.price }, { item: bell, quantity: 1, price: bell.price }, { item: helmet, quantity: 1, price: helmet.price }])
 
-order2 = kiera.orders.create!(name: kiera.name, address: kiera.address, city: kiera.city, state: kiera.state, zip: kiera.zip)
+order2 = kiera.orders.create!(name: kiera.name, address: kiera.address, city: kiera.city, state: kiera.state, zip: kiera.zip, status: "Shipped")
 order2.item_orders.create!([{ item: pull_toy, quantity: 2, price: pull_toy.price }, { item: dog_bone, quantity: 3, price: dog_bone.price }, { item: spring, quantity: 1, price: spring.price }])
 
-order3 = tim.orders.create!(name: tim.name, address: tim.address, city: tim.city, state: tim.state, zip: tim.zip)
+order3 = tim.orders.create!(name: tim.name, address: tim.address, city: tim.city, state: tim.state, zip: tim.zip, status: "Cancelled")
 order3.item_orders.create!(item: tire, quantity: 2, price: tire.price)
+
+order4 = tim.orders.create!(name: tim.name, address: tim.address, city: tim.city, state: tim.state, zip: tim.zip)
+order4.item_orders.create!(item: spring, quantity: 1, price: spring.price)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,7 +5,8 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
-
+ItemOrder.destroy_all
+Order.destroy_all
 User.destroy_all
 Merchant.destroy_all
 Item.destroy_all

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -36,3 +36,16 @@ kiera = User.create!(name: 'Kiera Allen', address: '124 Main St.', city: 'Denver
 sally = User.create!(name: 'Sally Peach', address: '432 Grove St.', city: 'Denver', state: 'CO', zip: 80205, email: 'sally@peach.com', password: 'password', role: 1)
 
 bob = User.create!(name: 'Bob Ross', address: '745 Rose St.', city: 'Denver', state: 'CO', zip: 80205, email: 'bob@ross.com', password: 'password', role: 2)
+
+tim = User.create!(name: 'Tim Tyrell', address: '421 Branch St.', city: 'Denver', state: 'CO', zip: 80205, email: 'you_hate@to_see_it.com', password: 'password', role: 0)
+
+# orders
+
+order1 = kiera.orders.create!(name: kiera.name, address: kiera.address, city: kiera.city, state: kiera.state, zip: kiera.zip)
+order1.item_orders.create!([{ item: tire, quantity: 2, price: tire.price }, { item: bell, quantity: 1, price: bell.price }, { item: helmet, quantity: 1, price: helmet.price }])
+
+order2 = kiera.orders.create!(name: kiera.name, address: kiera.address, city: kiera.city, state: kiera.state, zip: kiera.zip)
+order2.item_orders.create!([{ item: pull_toy, quantity: 2, price: pull_toy.price }, { item: dog_bone, quantity: 3, price: dog_bone.price }, { item: spring, quantity: 1, price: spring.price }])
+
+order3 = tim.orders.create!(name: tim.name, address: tim.address, city: tim.city, state: tim.state, zip: tim.zip)
+order3.item_orders.create!(item: tire, quantity: 2, price: tire.price)

--- a/spec/features/admin/dashboard_spec.rb
+++ b/spec/features/admin/dashboard_spec.rb
@@ -44,16 +44,19 @@ describe "As an admin user" do
           expect(page).to have_link(@order1.name)
           expect(page).to have_content(@order1.id)
           expect(page).to have_content(@order1.created_at.to_date)
+          expect(page).to have_content(@order1.status)
         end
         within "#order-#{@order2.id}" do
           expect(page).to have_link(@order2.name)
           expect(page).to have_content(@order2.id)
           expect(page).to have_content(@order2.created_at.to_date)
+          expect(page).to have_content(@order2.status)
         end
         within "#order-#{@order3.id}" do
           expect(page).to have_link(@order3.name)
           expect(page).to have_content(@order3.id)
           expect(page).to have_content(@order3.created_at.to_date)
+          expect(page).to have_content(@order3.status)
         end
       end
     end

--- a/spec/features/admin/dashboard_spec.rb
+++ b/spec/features/admin/dashboard_spec.rb
@@ -16,14 +16,17 @@ describe "As an admin user" do
     @user2 = User.create!(name: 'Tim Tyrell', address: '421 Branch St.', city: 'Denver', state: 'CO', zip: 80205, email: 'you_hate@to_see_it.com', password: 'password', role: 0)
     @admin = User.create!(name: 'Bob Ross', address: '745 Rose St.', city: 'Denver', state: 'CO', zip: 80205, email: 'bob@ross.com', password: 'password', role: 2)
 
-    @order1 = @user1.orders.create!(name: @user1.name, address: @user1.address, city: @user1.city, state: @user1.state, zip: @user1.zip)
+    @order1 = @user1.orders.create!(name: @user1.name, address: @user1.address, city: @user1.city, state: @user1.state, zip: @user1.zip, status: "shipped")
     @order1.item_orders.create!([{ item: @tire, quantity: 2, price: @tire.price }, { item: @bell, quantity: 1, price: @bell.price }, { item: @helmet, quantity: 1, price: @helmet.price }])
 
-    @order2 = @user1.orders.create!(name: @user1.name, address: @user1.address, city: @user1.city, state: @user1.state, zip: @user1.zip)
+    @order2 = @user1.orders.create!(name: @user1.name, address: @user1.address, city: @user1.city, state: @user1.state, zip: @user1.zip, status: "cancelled")
     @order2.item_orders.create!([{ item: @pull_toy, quantity: 2, price: @pull_toy.price }, { item: @dog_bone, quantity: 3, price: @dog_bone.price }, { item: @spring, quantity: 1, price: @spring.price }])
 
-    @order3 = @user2.orders.create!(name: @user2.name, address: @user2.address, city: @user2.city, state: @user2.state, zip: @user2.zip)
+    @order3 = @user2.orders.create!(name: @user2.name, address: @user2.address, city: @user2.city, state: @user2.state, zip: @user2.zip, status: "packaged")
     @order3.item_orders.create!(item: @tire, quantity: 2, price: @tire.price)
+
+    @order4 = @user2.orders.create!(name: @user2.name, address: @user2.address, city: @user2.city, state: @user2.state, zip: @user2.zip, status: "pending")
+    @order4.item_orders.create!(item: @spring, quantity: 1, price: @spring.price)
 
     visit '/login'
 
@@ -77,14 +80,13 @@ describe "As an admin user" do
 
       expect(current_path).to eq("/admin/users/#{@order3.user_id}")
     end
+    it "orders are sorted by status: packaged, pending, shipped, then cancelled" do
+      within '#all-orders' do
+        # Proper order is: @order3, @order4, @order1, @order2
+        expect("Order ID: #{@order3.id}").to appear_before("Order ID: #{@order4.id}")
+        expect("Order ID: #{@order4.id}").to appear_before("Order ID: #{@order1.id}")
+        expect("Order ID: #{@order1.id}").to appear_before("Order ID: #{@order2.id}")
+      end
+    end
   end
 end
-
-# User Story 32, Admin can see all orders
-#
-# Orders are sorted by "status" in this order:
-#
-# - packaged
-# - pending
-# - shipped
-# - cancelled

--- a/spec/features/admin/dashboard_spec.rb
+++ b/spec/features/admin/dashboard_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+describe "As an admin user" do
+  before :each do
+    @bike_shop = Merchant.create!(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+    @dog_shop = Merchant.create!(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80210)
+
+    @tire = @bike_shop.items.create!(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
+    @bell = @bike_shop.items.create!(name: "Silver Bell", description: "Let everyone know you're coming!", price: 25, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 10)
+    @helmet = @bike_shop.items.create!(name: "Helmet", description: "Protect your head!", price: 150, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 20)
+    @pull_toy = @dog_shop.items.create!(name: "Pull Toy", description: "Great pull toy!", price: 10, image: "http://lovencaretoys.com/image/cache/dog/tug-toy-dog-pull-9010_2-800x800.jpg", inventory: 32)
+    @dog_bone = @dog_shop.items.create!(name: "Dog Bone", description: "They'll love it!", price: 21, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", active?:false, inventory: 21)
+    @spring = @dog_shop.items.create!(name: "Spring Toy", description: "Best thing to chase", price: 7, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", inventory: 53)
+
+    @user1 = User.create!(name: 'Kiera Allen', address: '124 Main St.', city: 'Denver', state: 'CO', zip: 80205, email: 'bob@marley.com', password: 'password', role: 0)
+    @user2 = User.create!(name: 'Tim Tyrell', address: '421 Branch St.', city: 'Denver', state: 'CO', zip: 80205, email: 'you_hate@to_see_it.com', password: 'password', role: 0)
+    @admin = User.create!(name: 'Bob Ross', address: '745 Rose St.', city: 'Denver', state: 'CO', zip: 80205, email: 'bob@ross.com', password: 'password', role: 2)
+
+    @order1 = @user1.orders.create!(name: @user1.name, address: @user1.address, city: @user1.city, state: @user1.state, zip: @user1.zip)
+    @order1.item_orders.create!([{ item: @tire, quantity: 2, price: @tire.price }, { item: @bell, quantity: 1, price: @bell.price }, { item: @helmet, quantity: 1, price: @helmet.price }])
+
+    @order2 = @user1.orders.create!(name: @user1.name, address: @user1.address, city: @user1.city, state: @user1.state, zip: @user1.zip)
+    @order2.item_orders.create!([{ item: @pull_toy, quantity: 2, price: @pull_toy.price }, { item: @dog_bone, quantity: 3, price: @dog_bone.price }, { item: @spring, quantity: 1, price: @spring.price }])
+
+    @order3 = @user2.orders.create!(name: @user2.name, address: @user2.address, city: @user2.city, state: @user2.state, zip: @user2.zip)
+    @order3.item_orders.create!(item: @tire, quantity: 2, price: @tire.price)
+
+    visit '/login'
+
+    fill_in :email, with: @admin.email
+    fill_in :password, with: @admin.password
+
+    click_button 'Login'
+
+    visit '/admin'
+  end
+  describe "when I visit my admin dashboard ('/admin')" do
+    it "I see all orders in the system and each order's information" do
+      within '#all-orders' do
+        within "order-#{@order1.id}" do
+          expect(page).to have_link(@order1.user_id)
+          expect(page).to have_content(@order1.id)
+          expect(page).to have_content(@order1.created_at.to_date)
+        end
+        within "order-#{@order2.id}" do
+          expect(page).to have_link(@order2.user_id)
+          expect(page).to have_content(@order2.id)
+          expect(page).to have_content(@order2.created_at.to_date)
+        end
+        within "order-#{@order3.id}" do
+          expect(page).to have_link(@order3.user_id)
+          expect(page).to have_content(@order3.id)
+          expect(page).to have_content(@order3.created_at.to_date)
+        end
+      end
+    end
+  end
+end
+
+# User Story 32, Admin can see all orders
+# - user who placed the order, which links to admin view of user profile
+#
+# Orders are sorted by "status" in this order:
+#
+# - packaged
+# - pending
+# - shipped
+# - cancelled

--- a/spec/features/admin/dashboard_spec.rb
+++ b/spec/features/admin/dashboard_spec.rb
@@ -54,11 +54,33 @@ describe "As an admin user" do
         end
       end
     end
+    it "each user name under orders is a link to the admin view of that user's profile" do
+      within "#order-#{@order1.id}" do
+        click_link(@order1.name)
+      end
+
+      expect(current_path).to eq("/admin/users/#{@order1.user_id}")
+
+      visit '/admin'
+
+      within "#order-#{@order2.id}" do
+        click_link(@order2.name)
+      end
+
+      expect(current_path).to eq("/admin/users/#{@order2.user_id}")
+
+      visit '/admin'
+
+      within "#order-#{@order3.id}" do
+        click_link(@order3.name)
+      end
+
+      expect(current_path).to eq("/admin/users/#{@order3.user_id}")
+    end
   end
 end
 
 # User Story 32, Admin can see all orders
-# - user who placed the order, which links to admin view of user profile
 #
 # Orders are sorted by "status" in this order:
 #

--- a/spec/features/admin/dashboard_spec.rb
+++ b/spec/features/admin/dashboard_spec.rb
@@ -16,16 +16,16 @@ describe "As an admin user" do
     @user2 = User.create!(name: 'Tim Tyrell', address: '421 Branch St.', city: 'Denver', state: 'CO', zip: 80205, email: 'you_hate@to_see_it.com', password: 'password', role: 0)
     @admin = User.create!(name: 'Bob Ross', address: '745 Rose St.', city: 'Denver', state: 'CO', zip: 80205, email: 'bob@ross.com', password: 'password', role: 2)
 
-    @order1 = @user1.orders.create!(name: @user1.name, address: @user1.address, city: @user1.city, state: @user1.state, zip: @user1.zip, status: "shipped")
+    @order1 = @user1.orders.create!(name: @user1.name, address: @user1.address, city: @user1.city, state: @user1.state, zip: @user1.zip, status: "Shipped")
     @order1.item_orders.create!([{ item: @tire, quantity: 2, price: @tire.price }, { item: @bell, quantity: 1, price: @bell.price }, { item: @helmet, quantity: 1, price: @helmet.price }])
 
-    @order2 = @user1.orders.create!(name: @user1.name, address: @user1.address, city: @user1.city, state: @user1.state, zip: @user1.zip, status: "cancelled")
+    @order2 = @user1.orders.create!(name: @user1.name, address: @user1.address, city: @user1.city, state: @user1.state, zip: @user1.zip, status: "Cancelled")
     @order2.item_orders.create!([{ item: @pull_toy, quantity: 2, price: @pull_toy.price }, { item: @dog_bone, quantity: 3, price: @dog_bone.price }, { item: @spring, quantity: 1, price: @spring.price }])
 
-    @order3 = @user2.orders.create!(name: @user2.name, address: @user2.address, city: @user2.city, state: @user2.state, zip: @user2.zip, status: "packaged")
+    @order3 = @user2.orders.create!(name: @user2.name, address: @user2.address, city: @user2.city, state: @user2.state, zip: @user2.zip, status: "Packaged")
     @order3.item_orders.create!(item: @tire, quantity: 2, price: @tire.price)
 
-    @order4 = @user2.orders.create!(name: @user2.name, address: @user2.address, city: @user2.city, state: @user2.state, zip: @user2.zip, status: "pending")
+    @order4 = @user2.orders.create!(name: @user2.name, address: @user2.address, city: @user2.city, state: @user2.state, zip: @user2.zip, status: "Pending")
     @order4.item_orders.create!(item: @spring, quantity: 1, price: @spring.price)
 
     visit '/login'

--- a/spec/features/admin/dashboard_spec.rb
+++ b/spec/features/admin/dashboard_spec.rb
@@ -38,17 +38,17 @@ describe "As an admin user" do
     it "I see all orders in the system and each order's information" do
       within '#all-orders' do
         within "#order-#{@order1.id}" do
-          expect(page).to have_link(@order1.user_id)
+          expect(page).to have_link(@order1.name)
           expect(page).to have_content(@order1.id)
           expect(page).to have_content(@order1.created_at.to_date)
         end
         within "#order-#{@order2.id}" do
-          expect(page).to have_link(@order2.user_id)
+          expect(page).to have_link(@order2.name)
           expect(page).to have_content(@order2.id)
           expect(page).to have_content(@order2.created_at.to_date)
         end
         within "#order-#{@order3.id}" do
-          expect(page).to have_link(@order3.user_id)
+          expect(page).to have_link(@order3.name)
           expect(page).to have_content(@order3.id)
           expect(page).to have_content(@order3.created_at.to_date)
         end

--- a/spec/features/admin/dashboard_spec.rb
+++ b/spec/features/admin/dashboard_spec.rb
@@ -37,17 +37,17 @@ describe "As an admin user" do
   describe "when I visit my admin dashboard ('/admin')" do
     it "I see all orders in the system and each order's information" do
       within '#all-orders' do
-        within "order-#{@order1.id}" do
+        within "#order-#{@order1.id}" do
           expect(page).to have_link(@order1.user_id)
           expect(page).to have_content(@order1.id)
           expect(page).to have_content(@order1.created_at.to_date)
         end
-        within "order-#{@order2.id}" do
+        within "#order-#{@order2.id}" do
           expect(page).to have_link(@order2.user_id)
           expect(page).to have_content(@order2.id)
           expect(page).to have_content(@order2.created_at.to_date)
         end
-        within "order-#{@order3.id}" do
+        within "#order-#{@order3.id}" do
           expect(page).to have_link(@order3.user_id)
           expect(page).to have_content(@order3.id)
           expect(page).to have_content(@order3.created_at.to_date)

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -15,6 +15,15 @@ RSpec.describe "As an Admin" do
       @spring = @dog_shop.items.create(name: "Spring Toy", description: "Best thing to chase", price: 7, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", inventory: 53)
       @leash = @dog_shop.items.create(name: "Leash", description: "Walk that dog!", price: 15, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", inventory: 41)
       @octopus = @dog_shop.items.create(name: "Plush Octopus Toy", description: "Your dog will love this thing", price: 32, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", inventory: 12)
+
+      @admin = User.create!(name: 'Bob Ross', address: '745 Rose St.', city: 'Denver', state: 'CO', zip: 80205, email: 'bob@ross.com', password: 'password', role: 2)
+
+      visit '/login'
+
+      fill_in :email, with: @admin.email
+      fill_in :password, with: @admin.password
+
+      click_button 'Login'
     end
 
     it "I see a 'Disable' button next to any merchants not disabled" do

--- a/spec/features/items/destroy_spec.rb
+++ b/spec/features/items/destroy_spec.rb
@@ -27,11 +27,12 @@ RSpec.describe 'item delete', type: :feature do
       expect(Review.where(id:review_1.id)).to be_empty
     end
 
-    it 'I can not delete items with orders' do 
+    it 'I can not delete items with orders' do
       bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
       chain = bike_shop.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
       review_1 = chain.reviews.create(title: "Great place!", content: "They have great bike stuff and I'd recommend them to anyone.", rating: 5)
-      order_1 = Order.create!(name: 'Meg', address: '123 Stang St', city: 'Hershey', state: 'PA', zip: 80218)
+      user1 = User.create!(name: 'Kiera Allen', address: '124 Main St.', city: 'Denver', state: 'CO', zip: 80205, email: 'bob@marley.com', password: 'password', role: 0)
+      order_1 = user1.orders.create!(name: 'Meg', address: '123 Stang St', city: 'Hershey', state: 'PA', zip: 80218)
       order_1.item_orders.create!(item: chain, price: chain.price, quantity: 2)
 
       visit "/items/#{chain.id}"

--- a/spec/features/merchants/statistics_spec.rb
+++ b/spec/features/merchants/statistics_spec.rb
@@ -16,9 +16,11 @@ RSpec.describe 'merchant show page', type: :feature do
       @pull_toy = @brian.items.create(name: "Pull Toy", description: "Great pull toy!", price: 10, image: "http://lovencaretoys.com/image/cache/dog/tug-toy-dog-pull-9010_2-800x800.jpg", inventory: 32)
       @dog_bone = @brian.items.create(name: "Dog Bone", description: "They'll love it!", price: 20, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", active?:false, inventory: 21)
 
-      @order_1 = Order.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17033)
-      @order_2 = Order.create!(name: 'Brian', address: '123 Zanti St', city: 'Denver', state: 'CO', zip: 80204)
-      @order_3 = Order.create!(name: 'Mike', address: '123 Dao St', city: 'Denver', state: 'CO', zip: 80210)
+      @user1 = User.create!(name: 'Kiera Allen', address: '124 Main St.', city: 'Denver', state: 'CO', zip: 80205, email: 'bob@marley.com', password: 'password', role: 0)
+
+      @order_1 = @user1.orders.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17033)
+      @order_2 = @user1.orders.create!(name: 'Brian', address: '123 Zanti St', city: 'Denver', state: 'CO', zip: 80204)
+      @order_3 = @user1.orders.create!(name: 'Mike', address: '123 Dao St', city: 'Denver', state: 'CO', zip: 80210)
 
       @order_1.item_orders.create!(item: @tire, price: @tire.price, quantity: 2)
       @order_1.item_orders.create!(item: @pull_toy, price: @pull_toy.price, quantity: 3)

--- a/spec/models/item_orders_spec.rb
+++ b/spec/models/item_orders_spec.rb
@@ -17,7 +17,9 @@ describe ItemOrder, type: :model do
     it "can be created as a default of pending" do
       meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
       tire = meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
-      order_1 = Order.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17033)
+      user1 = User.create!(name: 'Kiera Allen', address: '124 Main St.', city: 'Denver', state: 'CO', zip: 80205, email: 'bob@marley.com', password: 'password', role: 0)
+
+      order_1 = user1.orders.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17033)
       item_order_1 = order_1.item_orders.create!(item_id: tire.id, price: 4.50, quantity: 2)
 
       expect(item_order_1.status).to eq("pending")
@@ -28,7 +30,9 @@ describe ItemOrder, type: :model do
     it "can be unfulfilled if order is cancelled" do
       meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
       tire = meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
-      order_1 = Order.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17033)
+      user1 = User.create!(name: 'Kiera Allen', address: '124 Main St.', city: 'Denver', state: 'CO', zip: 80205, email: 'bob@marley.com', password: 'password', role: 0)
+
+      order_1 = user1.orders.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17033)
       item_order_1 = order_1.item_orders.create!(item_id: tire.id, price: 4.50, quantity: 2)
 
       item_order_1.update(status: "unfulfilled")
@@ -43,7 +47,9 @@ describe ItemOrder, type: :model do
     it 'subtotal' do
       meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
       tire = meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
-      order_1 = Order.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17033)
+      user1 = User.create!(name: 'Kiera Allen', address: '124 Main St.', city: 'Denver', state: 'CO', zip: 80205, email: 'bob@marley.com', password: 'password', role: 0)
+
+      order_1 = user1.orders.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17033)
       item_order_1 = order_1.item_orders.create!(item: tire, price: tire.price, quantity: 2)
 
       expect(item_order_1.subtotal).to eq(200)

--- a/spec/models/item_orders_spec.rb
+++ b/spec/models/item_orders_spec.rb
@@ -45,7 +45,8 @@ describe ItemOrder, type: :model do
     it "can be fulfilled if order is fulfilled by merchant" do
       meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
       tire = meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
-      order_1 = Order.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17033)
+      user1 = User.create!(name: 'Kiera Allen', address: '124 Main St.', city: 'Denver', state: 'CO', zip: 80205, email: 'bob@marley.com', password: 'password', role: 0)
+      order_1 = user1.orders.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17033)
       item_order_1 = order_1.item_orders.create!(item_id: tire.id, price: 4.50, quantity: 2)
 
       item_order_1.update(status: "fulfilled")

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -19,8 +19,8 @@ describe Item, type: :model do
 
   describe "instance methods" do
     before(:each) do
-      @bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
-      @chain = @bike_shop.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
+      @bike_shop = Merchant.create!(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+      @chain = @bike_shop.items.create!(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
 
       @tire = @bike_shop.items.create!(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
       @bell = @bike_shop.items.create!(name: "Silver Bell", description: "Let everyone know you're coming!", price: 25, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 10)
@@ -32,8 +32,8 @@ describe Item, type: :model do
       @sheryl = User.create!(name: 'Sheryl S', address: '124 Main St.', city: 'Denver', state: 'CO', zip: 80205, email: 'sheryl@marley.com', password: 'password', role: 0)
       @curtis = User.create!(name: 'Curtis B', address: '124 Main St.', city: 'Denver', state: 'CO', zip: 80205, email: 'curtis@marley.com', password: 'password', role: 0)
 
-      @order_1 = Order.create!(name: "name", address: "address", city: "city", state: "state", zip: 23455, user_id: @sheryl.id)
-      @order_2 = Order.create!(name: "name", address: "address", city: "city", state: "state", zip: 80203, user_id: @curtis.id)
+      @order_1 = @sheryl.orders.create!(name: "name", address: "address", city: "city", state: "state", zip: 23455, user_id: @sheryl.id)
+      @order_2 = @curtis.orders.create!(name: "name", address: "address", city: "city", state: "state", zip: 80203, user_id: @curtis.id)
 
       ItemOrder.create!(order_id: @order_1.id, price: 1.0, item_id: @tire.id, quantity: 5)
       ItemOrder.create!(order_id: @order_1.id, price: 1.0, item_id: @bell.id, quantity: 1)
@@ -45,11 +45,11 @@ describe Item, type: :model do
       ItemOrder.create!(order_id: @order_2.id, price: 1.0, item_id: @kickstand.id, quantity: 4)
       ItemOrder.create!(order_id: @order_2.id, price: 1.0, item_id: @seat.id, quantity: 4)
 
-      @review_1 = @chain.reviews.create(title: "Great place!", content: "They have great bike stuff and I'd recommend them to anyone.", rating: 5)
-      @review_2 = @chain.reviews.create(title: "Cool shop!", content: "They have cool bike stuff and I'd recommend them to anyone.", rating: 4)
-      @review_3 = @chain.reviews.create(title: "Meh place", content: "They have meh bike stuff and I probably won't come back", rating: 1)
-      @review_4 = @chain.reviews.create(title: "Not too impressed", content: "v basic bike shop", rating: 2)
-      @review_5 = @chain.reviews.create(title: "Okay place :/", content: "Brian's cool and all but just an okay selection of items", rating: 3)
+      @review_1 = @chain.reviews.create!(title: "Great place!", content: "They have great bike stuff and I'd recommend them to anyone.", rating: 5)
+      @review_2 = @chain.reviews.create!(title: "Cool shop!", content: "They have cool bike stuff and I'd recommend them to anyone.", rating: 4)
+      @review_3 = @chain.reviews.create!(title: "Meh place", content: "They have meh bike stuff and I probably won't come back", rating: 1)
+      @review_4 = @chain.reviews.create!(title: "Not too impressed", content: "v basic bike shop", rating: 2)
+      @review_5 = @chain.reviews.create!(title: "Okay place :/", content: "Brian's cool and all but just an okay selection of items", rating: 3)
     end
 
     it "total_sold" do
@@ -74,7 +74,7 @@ describe Item, type: :model do
 
     it 'no orders' do
       expect(@chain.no_orders?).to eq(true)
-      order = Order.create(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17033)
+      order = @curtis.orders.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17033)
       order.item_orders.create(item: @chain, price: @chain.price, quantity: 2)
       expect(@chain.no_orders?).to eq(false)
     end
@@ -92,8 +92,8 @@ describe Item, type: :model do
 
       @kiera = User.create!(name: 'Kiera Allen', address: '124 Main St.', city: 'Denver', state: 'CO', zip: 80205, email: 'bob@marley.com', password: 'password', role: 0)
 
-      @order_1 = Order.create!(name: "name", address: "address", city: "city", state: "state", zip: 23455, user_id: @kiera.id)
-      @order_2 = Order.create!(name: "name", address: "address", city: "city", state: "state", zip: 80203, user_id: @kiera.id)
+      @order_1 = @kiera.orders.create!(name: "name", address: "address", city: "city", state: "state", zip: 23455, user_id: @kiera.id)
+      @order_2 = @kiera.orders.create!(name: "name", address: "address", city: "city", state: "state", zip: 80203, user_id: @kiera.id)
 
       ItemOrder.create!(order_id: @order_1.id, price: 1.0, item_id: @streamers.id, quantity: 5)
       ItemOrder.create!(order_id: @order_1.id, price: 1.0, item_id: @seat.id, quantity: 1)

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -18,11 +18,12 @@ describe Merchant, type: :model do
     before(:each) do
       @meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
       @tire = @meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
+      @user1 = User.create!(name: 'Kiera Allen', address: '124 Main St.', city: 'Denver', state: 'CO', zip: 80205, email: 'bob@marley.com', password: 'password', role: 0)
     end
     it 'no_orders' do
       expect(@meg.no_orders?).to eq(true)
 
-      order_1 = Order.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17033)
+      order_1 = @user1.orders.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17033)
       item_order_1 = order_1.item_orders.create!(item: @tire, price: @tire.price, quantity: 2)
 
       expect(@meg.no_orders?).to eq(false)
@@ -42,9 +43,9 @@ describe Merchant, type: :model do
 
     it 'distinct_cities' do
       chain = @meg.items.create(name: "Chain", description: "It'll never break!", price: 40, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 22)
-      order_1 = Order.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17033)
-      order_2 = Order.create!(name: 'Brian', address: '123 Brian Ave', city: 'Denver', state: 'CO', zip: 17033)
-      order_3 = Order.create!(name: 'Dao', address: '123 Mike Ave', city: 'Denver', state: 'CO', zip: 17033)
+      order_1 = @user1.orders.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17033)
+      order_2 = @user1.orders.create!(name: 'Brian', address: '123 Brian Ave', city: 'Denver', state: 'CO', zip: 17033)
+      order_3 = @user1.orders.create!(name: 'Dao', address: '123 Mike Ave', city: 'Denver', state: 'CO', zip: 17033)
       order_1.item_orders.create!(item: @tire, price: @tire.price, quantity: 2)
       order_2.item_orders.create!(item: chain, price: chain.price, quantity: 2)
       order_3.item_orders.create!(item: @tire, price: @tire.price, quantity: 2)

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -18,15 +18,15 @@ describe Order, type: :model do
   describe "enum" do
     it "status" do
       user1 = User.create!(name: 'Kiera Allen', address: '124 Main St.', city: 'Denver', state: 'CO', zip: 80205, email: 'bob@marley.com', password: 'password', role: 0)
-      order1 = user1.orders.create!(name: user1.name, address: user1.address, city: user1.city, state: user1.state, zip: user1.zip, status: 3)
-      order2 = user1.orders.create!(name: user1.name, address: user1.address, city: user1.city, state: user1.state, zip: user1.zip, status: 4)
+      order1 = user1.orders.create!(name: user1.name, address: user1.address, city: user1.city, state: user1.state, zip: user1.zip, status: 2)
+      order2 = user1.orders.create!(name: user1.name, address: user1.address, city: user1.city, state: user1.state, zip: user1.zip, status: 3)
       order3 = user1.orders.create!(name: user1.name, address: user1.address, city: user1.city, state: user1.state, zip: user1.zip, status: 0)
       order4 = user1.orders.create!(name: user1.name, address: user1.address, city: user1.city, state: user1.state, zip: user1.zip, status: 1)
 
-      expect(order1.status).to eq('shipped')
-      expect(order2.status).to eq('cancelled')
-      expect(order3.status).to eq('packaged')
-      expect(order4.status).to eq('pending')
+      expect(order1.status).to eq('Shipped')
+      expect(order2.status).to eq('Cancelled')
+      expect(order3.status).to eq('Packaged')
+      expect(order4.status).to eq('Pending')
     end
   end
 

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -12,6 +12,7 @@ describe Order, type: :model do
   describe "relationships" do
     it {should have_many :item_orders}
     it {should have_many(:items).through(:item_orders)}
+    it { should belong_to(:user) }
   end
 
   describe 'instance methods' do

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -23,7 +23,9 @@ describe Order, type: :model do
       @tire = @meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
       @pull_toy = @brian.items.create(name: "Pull Toy", description: "Great pull toy!", price: 10, image: "http://lovencaretoys.com/image/cache/dog/tug-toy-dog-pull-9010_2-800x800.jpg", inventory: 32)
 
-      @order_1 = Order.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17033)
+      @user1 = User.create!(name: 'Kiera Allen', address: '124 Main St.', city: 'Denver', state: 'CO', zip: 80205, email: 'bob@marley.com', password: 'password', role: 0)
+
+      @order_1 = @user1.orders.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17033)
 
       @order_1.item_orders.create!(item: @tire, price: @tire.price, quantity: 2)
       @order_1.item_orders.create!(item: @pull_toy, price: @pull_toy.price, quantity: 3)

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -60,16 +60,16 @@ describe Order, type: :model do
       expect(@order_1.all_fulfilled?).to be_truthy
     end
   end
-  # describe "class methods" do
-  #   xit "::status_sorted" do
-  #     user1 = User.create!(name: 'Kiera Allen', address: '124 Main St.', city: 'Denver', state: 'CO', zip: 80205, email: 'bob@marley.com', password: 'password', role: 0)
-  #     order1 = user1.orders.create!(name: user1.name, address: user1.address, city: user1.city, state: user1.state, zip: user1.zip, status: "shipped")
-  #     order2 = user1.orders.create!(name: user1.name, address: user1.address, city: user1.city, state: user1.state, zip: user1.zip, status: "cancelled")
-  #     order3 = user1.orders.create!(name: user1.name, address: user1.address, city: user1.city, state: user1.state, zip: user1.zip, status: "packaged")
-  #     order4 = user1.orders.create!(name: user1.name, address: user1.address, city: user1.city, state: user1.state, zip: user1.zip, status: "pending")
-  #     expected = [order3, order4, order1, order2]
-  #
-  #     expect(Order.status_sorted).to eq(expected)
-  #   end
-  # end
+  describe "class methods" do
+    it "::status_sorted" do
+      user1 = User.create!(name: 'Kiera Allen', address: '124 Main St.', city: 'Denver', state: 'CO', zip: 80205, email: 'bob@marley.com', password: 'password', role: 0)
+      order1 = user1.orders.create!(name: user1.name, address: user1.address, city: user1.city, state: user1.state, zip: user1.zip, status: "Shipped")
+      order2 = user1.orders.create!(name: user1.name, address: user1.address, city: user1.city, state: user1.state, zip: user1.zip, status: "Cancelled")
+      order3 = user1.orders.create!(name: user1.name, address: user1.address, city: user1.city, state: user1.state, zip: user1.zip, status: "Packaged")
+      order4 = user1.orders.create!(name: user1.name, address: user1.address, city: user1.city, state: user1.state, zip: user1.zip, status: "Pending")
+      expected = [order3, order4, order1, order2]
+
+      expect(Order.status_sorted).to eq(expected)
+    end
+  end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -15,6 +15,21 @@ describe Order, type: :model do
     it { should belong_to(:user) }
   end
 
+  describe "enum" do
+    it "status" do
+      user1 = User.create!(name: 'Kiera Allen', address: '124 Main St.', city: 'Denver', state: 'CO', zip: 80205, email: 'bob@marley.com', password: 'password', role: 0)
+      order1 = user1.orders.create!(name: user1.name, address: user1.address, city: user1.city, state: user1.state, zip: user1.zip, status: 3)
+      order2 = user1.orders.create!(name: user1.name, address: user1.address, city: user1.city, state: user1.state, zip: user1.zip, status: 4)
+      order3 = user1.orders.create!(name: user1.name, address: user1.address, city: user1.city, state: user1.state, zip: user1.zip, status: 0)
+      order4 = user1.orders.create!(name: user1.name, address: user1.address, city: user1.city, state: user1.state, zip: user1.zip, status: 1)
+
+      expect(order1.status).to eq('shipped')
+      expect(order2.status).to eq('cancelled')
+      expect(order3.status).to eq('packaged')
+      expect(order4.status).to eq('pending')
+    end
+  end
+
   describe 'instance methods' do
     before :each do
       @meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
@@ -45,16 +60,16 @@ describe Order, type: :model do
       expect(@order_1.all_fulfilled?).to be_truthy
     end
   end
-  describe "class methods" do
-    it "::status_sorted" do
-      user1 = User.create!(name: 'Kiera Allen', address: '124 Main St.', city: 'Denver', state: 'CO', zip: 80205, email: 'bob@marley.com', password: 'password', role: 0)
-      order1 = user1.orders.create!(name: user1.name, address: user1.address, city: user1.city, state: user1.state, zip: user1.zip, status: "shipped")
-      order2 = user1.orders.create!(name: user1.name, address: user1.address, city: user1.city, state: user1.state, zip: user1.zip, status: "cancelled")
-      order3 = user1.orders.create!(name: user1.name, address: user1.address, city: user1.city, state: user1.state, zip: user1.zip, status: "packaged")
-      order4 = user1.orders.create!(name: user1.name, address: user1.address, city: user1.city, state: user1.state, zip: user1.zip, status: "pending")
-      expected = [order3, order4, order1, order2]
-
-      expect(Order.status_sorted).to eq(expected)
-    end
-  end
+  # describe "class methods" do
+  #   xit "::status_sorted" do
+  #     user1 = User.create!(name: 'Kiera Allen', address: '124 Main St.', city: 'Denver', state: 'CO', zip: 80205, email: 'bob@marley.com', password: 'password', role: 0)
+  #     order1 = user1.orders.create!(name: user1.name, address: user1.address, city: user1.city, state: user1.state, zip: user1.zip, status: "shipped")
+  #     order2 = user1.orders.create!(name: user1.name, address: user1.address, city: user1.city, state: user1.state, zip: user1.zip, status: "cancelled")
+  #     order3 = user1.orders.create!(name: user1.name, address: user1.address, city: user1.city, state: user1.state, zip: user1.zip, status: "packaged")
+  #     order4 = user1.orders.create!(name: user1.name, address: user1.address, city: user1.city, state: user1.state, zip: user1.zip, status: "pending")
+  #     expected = [order3, order4, order1, order2]
+  #
+  #     expect(Order.status_sorted).to eq(expected)
+  #   end
+  # end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -45,4 +45,16 @@ describe Order, type: :model do
       expect(@order_1.all_fulfilled?).to be_truthy
     end
   end
+  describe "class methods" do
+    it "::status_sorted" do
+      user1 = User.create!(name: 'Kiera Allen', address: '124 Main St.', city: 'Denver', state: 'CO', zip: 80205, email: 'bob@marley.com', password: 'password', role: 0)
+      order1 = user1.orders.create!(name: user1.name, address: user1.address, city: user1.city, state: user1.state, zip: user1.zip, status: "shipped")
+      order2 = user1.orders.create!(name: user1.name, address: user1.address, city: user1.city, state: user1.state, zip: user1.zip, status: "cancelled")
+      order3 = user1.orders.create!(name: user1.name, address: user1.address, city: user1.city, state: user1.state, zip: user1.zip, status: "packaged")
+      order4 = user1.orders.create!(name: user1.name, address: user1.address, city: user1.city, state: user1.state, zip: user1.zip, status: "pending")
+      expected = [order3, order4, order1, order2]
+
+      expect(Order.status_sorted).to eq(expected)
+    end
+  end
 end


### PR DESCRIPTION
Adds a list of all orders, sorted by status, to the admin dashboard with links to user profiles
---
- Changes order status to an enum (for sorting purposes)
- Adds an admin users controller
- Pulls admin user verification out of individual controllers into admin base controller
- Adds order seeds
- Adds an empty admin view for user profiles
- Order now belongs to user
- Closes #32 