### PR TITLE
Merchant activates an item

### DIFF
--- a/app/controllers/merchant/items_controller.rb
+++ b/app/controllers/merchant/items_controller.rb
@@ -5,11 +5,16 @@ class Merchant::ItemsController < ApplicationController
     @items = current_user.merchant.items
   end
 
-  def deactivate
+  def update
     merchant = current_user.merchant
     item = merchant.items.find(params[:item_id])
-    item.update(active?: false)
-    flash[:mesage] = "Your item is now inactive and no longer for sale."
+    if item.active?
+      item.update(active?: false)
+      flash[:mesage] = "Your item is now inactive and no longer for sale."
+    else
+      item.update(active?: true)
+      flash[:mesage] = "Your item is now active and is now available for sale."
+    end
     redirect_to '/merchant/items'
   end
 

--- a/app/views/merchant/items/index.html.erb
+++ b/app/views/merchant/items/index.html.erb
@@ -13,6 +13,7 @@
         <p><%= button_to "Deactivate", "/merchant/items/", method: :patch, id: "deactivate-#{item.id}", params: {item_id: item.id} %></p>
       <% else %>
         <p>Status: Inactive </p>
+        <p><%= button_to "Activate", "/merchant/items/", method: :patch, id: "activate-#{item.id}", params: {item_id: item.id} %></p>
       <% end %>
     </section>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,7 +63,7 @@ Rails.application.routes.draw do
     patch "/", to: "dashboard#update"
     get "/items", to: "items#index"
     get "/orders/:id", to: "orders#show"
-    patch "/items", to: "items#deactivate"
+    patch "/items", to: "items#update"
   end
 
   namespace :admin do

--- a/spec/features/merchant/items/index_spec.rb
+++ b/spec/features/merchant/items/index_spec.rb
@@ -61,5 +61,19 @@ RSpec.describe 'As a merchant employee', type: :feature do
 
       expect(page).to have_content("Your item is now inactive and no longer for sale.")
     end
+
+    it "shows a button to activate the item next to each item that is inactive, and when I click on the 'activate' button I am returned to my items page, I see a flash message indicating this item is now available for sale, and I see the item is now active" do
+      visit '/merchant/items'
+
+      find("#activate-#{@dog_bone.id}").click
+
+      expect(current_path).to eq('/merchant/items')
+
+      within("#item-#{@dog_bone.id}") do
+        expect(page).to have_content("Status: Active")
+      end
+
+      expect(page).to have_content("Your item is now active and is now available for sale.")
+    end
   end
 end


### PR DESCRIPTION
This PR will:
- Add activate button next to inactive items on merchant items index page
- Update methods to be even _more_ RESTful!
      - Instead of `"items#activate"` and `"items#deactivate"`, I combined them into on `"items#update"` method
- All tests passing
- closes #43 