### PR TITLE
Admin can ship orders

### DIFF
--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -1,0 +1,8 @@
+class Admin::OrdersController < Admin::BaseController
+  def update
+    order = Order.find(params[:order_id])
+    order.update(status: "Shipped")
+    flash[:success] = "Order #{order.id} has been shipped successfully."
+    redirect_to '/admin'
+  end
+end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -12,6 +12,8 @@
         <%= "Created On: #{order.created_at.to_date}" %>
         <%= content_tag :br %>
         <%= "Users: " %><%= link_to order.name, "admin/users/#{order.user_id}" %>
+        <%= content_tag :br %>
+          <%= button_to 'Ship', 'path', method: :patch if order.status == "Packaged" %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -12,8 +12,8 @@
         <%= "Created On: #{order.created_at.to_date}" %>
         <%= content_tag :br %>
         <%= "Users: " %><%= link_to order.name, "admin/users/#{order.user_id}" %>
-        <%= content_tag :br %>
-          <%= button_to 'Ship', 'path', method: :patch if order.status == "Packaged" %>
+        <%= content_tag :br if order.status == "Packaged" %>
+        <%= button_to 'Ship', "/admin/orders/#{order.id}", method: :patch if order.status == "Packaged" %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -12,8 +12,10 @@
         <%= "Created On: #{order.created_at.to_date}" %>
         <%= content_tag :br %>
         <%= "Users: " %><%= link_to order.name, "admin/users/#{order.user_id}" %>
-        <%= content_tag :br if order.status == "Packaged" %>
-        <%= button_to 'Ship', "/admin/orders/#{order.id}", method: :patch if order.status == "Packaged" %>
+        <% if order.status == "Packaged" %>
+          <%= content_tag :br %>
+          <%= button_to 'Ship', "/admin/orders/#{order.id}", method: :patch %>
+        <% end %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -63,6 +63,8 @@
 <section id="dateupdated">
   <p>Date Last Updated: <%= @order.updated_at%></p>
 </section>
-<section id="cancel-order">
-  <p><%= button_to "Cancel Order", "/profile/orders/#{@order.id}", method: :patch %></p>
-</section>
+<% if @order.status != "Shipped" && @order.status != "Cancelled" %>
+  <section id="cancel-order">
+    <p><%= button_to "Cancel Order", "/profile/orders/#{@order.id}", method: :patch %></p>
+  </section>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,5 +73,6 @@ Rails.application.routes.draw do
     get "/merchants", to: "merchants#index"
     patch "/merchants/:merchant_id/disable", to: "merchants#disable"
     patch "/merchants/:merchant_id/enable", to: "merchants#enable"
+    patch "/orders/:order_id", to: "orders#update"
   end
 end

--- a/spec/features/admin/dashboard_spec.rb
+++ b/spec/features/admin/dashboard_spec.rb
@@ -91,5 +91,59 @@ describe "As an admin user" do
         expect("Order ID: #{@order1.id}").to appear_before("Order ID: #{@order2.id}")
       end
     end
+    it "I can ship orders with a status of 'packaged'" do
+      within "#order-#{@order1.id}" do
+        expect(page).to_not have_content("Packaged")
+        expect(page).to_not have_button('Ship')
+      end
+      within "#order-#{@order2.id}" do
+        expect(page).to_not have_content("Packaged")
+        expect(page).to_not have_button('Ship')
+      end
+      within "#order-#{@order4.id}" do
+        expect(page).to_not have_content("Packaged")
+        expect(page).to_not have_button('Ship')
+      end
+      within "#order-#{@order3.id}" do
+        expect(page).to have_content("Packaged")
+        click_button('Ship')
+      end
+      within "#order-#{@order3.id}" do
+        expect(page).to_not have_content("Packaged")
+        expect(page).to have_content("Shipped")
+        expect(page).to_not have_button('Ship')
+      end
+    end
+    it "after I have shipped an order, the user can no longer cancel it" do
+      # As admin
+      within "#order-#{@order3.id}" do
+        expect(page).to have_content("Packaged")
+        click_button('Ship')
+      end
+
+      click_link 'Logout'
+
+      visit '/login'
+
+      fill_in :email, with: @user2.email
+      fill_in :password, with: @user2.password
+
+      click_button 'Login'
+
+      # As user2
+
+      visit "/profile/orders/#{@order3.id}"
+
+      expect(page).to_not have_css('#cancel-order')
+    end
   end
 end
+#
+# User Story 33, Admin can "ship" an order
+#
+# As an admin user X
+# When I log into my dashboard, "/admin" X
+# Then I see any "packaged" orders ready to ship. X
+# Next to each order I see a button to "ship" the order. X
+# When I click that button for an order, the status of that order changes to "shipped" X
+# And the user can no longer "cancel" the order. X

--- a/spec/features/admin/dashboard_spec.rb
+++ b/spec/features/admin/dashboard_spec.rb
@@ -108,6 +108,10 @@ describe "As an admin user" do
         expect(page).to have_content("Packaged")
         click_button('Ship')
       end
+
+      expect(current_path).to eq("/admin")
+      expect(page).to have_content("Order #{@order3.id} has been shipped successfully.")
+
       within "#order-#{@order3.id}" do
         expect(page).to_not have_content("Packaged")
         expect(page).to have_content("Shipped")

--- a/spec/features/admin/dashboard_spec.rb
+++ b/spec/features/admin/dashboard_spec.rb
@@ -142,12 +142,3 @@ describe "As an admin user" do
     end
   end
 end
-#
-# User Story 33, Admin can "ship" an order
-#
-# As an admin user X
-# When I log into my dashboard, "/admin" X
-# Then I see any "packaged" orders ready to ship. X
-# Next to each order I see a button to "ship" the order. X
-# When I click that button for an order, the status of that order changes to "shipped" X
-# And the user can no longer "cancel" the order. X


### PR DESCRIPTION
Adds a button to the admin dashboard allowing the admin to ship packaged orders. Also adds functionality to hide the cancel button from a user on shipped and cancelled orders.

---
- Adds ship button to admin dashboard
- Adds logic to user side 'Cancel Order' button to hide or show based on status
- Adds `Admin::UsersController`
- All tests passing
- Closes #33  