### PR TITLE
Merchant sees order show page

### DIFF
--- a/app/controllers/merchant/orders_controller.rb
+++ b/app/controllers/merchant/orders_controller.rb
@@ -4,6 +4,7 @@ class Merchant::OrdersController < ApplicationController
   def show
     merchant = current_user.merchant
     @item_orders = merchant.item_orders.where("order_id = #{params[:id]}")
+    @order = Order.find(params[:id])
   end
 
   private

--- a/app/controllers/merchant/orders_controller.rb
+++ b/app/controllers/merchant/orders_controller.rb
@@ -2,8 +2,8 @@ class Merchant::OrdersController < ApplicationController
   before_action :require_merchant
 
   def show
-    merchant = current_user.merchant
-    @item_orders = merchant.item_orders.where("order_id = #{params[:id]}")
+    # @merchant = current_user.merchant
+    @item_orders = current_user.merchant.item_orders.where("order_id = #{params[:id]}")
     @order = Order.find(params[:id])
   end
 

--- a/app/views/merchant/orders/show.html.erb
+++ b/app/views/merchant/orders/show.html.erb
@@ -1,10 +1,30 @@
-<%= content_tag :h1, "Order # #{params[:id]}" %>
+<%= content_tag :h1, "Order ##{params[:id]}" %>
+
+<section id="shipping-address">
+  <h3>Shipping Info</h3>
+    <table>
+      <tr>
+        <th>Name</th>
+        <th>Address</th>
+        <th>City</th>
+        <th>State</th>
+        <th>Zip</th>
+      </tr>
+      <tr>
+        <td><p><%= @order.name %></p></td>
+        <td><p><%= @order.address %></p></td>
+        <td><p><%= @order.city %></p></td>
+        <td><p><%= @order.state %></p></td>
+        <td><p><%= @order.zip %></p></td>
+      </tr>
+    </table>
+</section>
 
 <ul>
   <% @item_orders.each do |item_order| %>
-  <% if item_order.status != "fulfilled" %>
-  <li><%= content_tag :p, item_order.item.name %></li>
-  <%= button_to "Fulfill", "/merchant/", method: :patch, id: "item_order-#{item_order.id}", params: {item_order_id: item_order.id} %>
-  <% end %>
+    <% if item_order.status != "fulfilled" %>
+      <li><%= content_tag :p, item_order.item.name %></li>
+      <%= button_to "Fulfill", "/merchant/", method: :patch, id: "item_order-#{item_order.id}", params: {item_order_id: item_order.id} %>
+    <% end %>
   <% end %>
 </ul>

--- a/app/views/merchant/orders/show.html.erb
+++ b/app/views/merchant/orders/show.html.erb
@@ -21,25 +21,14 @@
 </section>
 
 <h3>Order Info</h3>
-  <table>
-    <tr>
-      <th>Item</th>
-      <th>Image</th>
-      <th>Price</th>
-      <th>Quantity</th>
-    </tr>
-    <tr>
-    <% @item_orders.each do |item_order| %>
-    <section id="#item-<%= item_order.item_id %>">
-      <td><p><%= link_to item_order.item.name, "/items/#{item_order.item_id}" %></p></td>
-      <td><p><%= image_tag "#{item_order.item.image}" %></p></td>
-      <td><p><%= item_order.quantity %></p></td>
-      <td><p><%= item_order.price %></p></td>
+<% @item_orders.each do |item_order| %>
+  <section id="#item-<%= item_order.item_id %>">
+  <p>Item: <%= link_to item_order.item.name, "/items/#{item_order.item_id}" %></p>
+  <p>Image: <%= image_tag "#{item_order.item.image}" %></p>
+  <p>Price: <%= number_to_currency(item_order.price) %></p>
+  <p>Quantity: <%= item_order.quantity %></p>
   <% if item_order.status != "fulfilled" %>
-    <li><%= content_tag :p, item_order.item.name %></li>
     <%= button_to "Fulfill", "/merchant/", method: :patch, id: "item_order-#{item_order.id}", params: {item_order_id: item_order.id} %>
   <% end %>
-    </section>
-    <% end %>
-    </tr>
-</table>
+  </section>
+<% end %>

--- a/app/views/merchant/orders/show.html.erb
+++ b/app/views/merchant/orders/show.html.erb
@@ -1,4 +1,4 @@
-<%= content_tag :h1, "Order ##{params[:id]}" %>
+<h1>Order #<%= @order.id %></h1>
 
 <section id="shipping-address">
   <h3>Shipping Info</h3>
@@ -20,11 +20,26 @@
     </table>
 </section>
 
-<ul>
-  <% @item_orders.each do |item_order| %>
-    <% if item_order.status != "fulfilled" %>
-      <li><%= content_tag :p, item_order.item.name %></li>
-      <%= button_to "Fulfill", "/merchant/", method: :patch, id: "item_order-#{item_order.id}", params: {item_order_id: item_order.id} %>
-    <% end %>
+<h3>Order Info</h3>
+  <table>
+    <tr>
+      <th>Item</th>
+      <th>Image</th>
+      <th>Price</th>
+      <th>Quantity</th>
+    </tr>
+    <tr>
+    <% @item_orders.each do |item_order| %>
+    <section id="#item-<%= item_order.item_id %>">
+      <td><p><%= link_to item_order.item.name, "/items/#{item_order.item_id}" %></p></td>
+      <td><p><%= image_tag "#{item_order.item.image}" %></p></td>
+      <td><p><%= item_order.quantity %></p></td>
+      <td><p><%= item_order.price %></p></td>
+  <% if item_order.status != "fulfilled" %>
+    <li><%= content_tag :p, item_order.item.name %></li>
+    <%= button_to "Fulfill", "/merchant/", method: :patch, id: "item_order-#{item_order.id}", params: {item_order_id: item_order.id} %>
   <% end %>
-</ul>
+    </section>
+    <% end %>
+    </tr>
+</table>

--- a/spec/features/merchant/orders/show_spec.rb
+++ b/spec/features/merchant/orders/show_spec.rb
@@ -40,7 +40,6 @@ RSpec.describe 'merchant order show page' do
 
       expect(page).to have_content(@order_1.id)
       expect(page).to have_content(@dog_bone.name)
-      expect(page).to_not have_content(@pull_toy.name)
     end
 
     it "shows the recipient's name and address used to create order" do
@@ -60,14 +59,25 @@ RSpec.describe 'merchant order show page' do
 
       expect(page).to_not have_content(@tire.name)
     end
+
+    it "shows each item's name (which is a link to that item's show page), image, price, and quantity user wants to purchase" do
+
+      visit "/merchant/orders/#{@order_1.id}"
+
+      click_link "#{@pull_toy.name}"
+      expect(current_path).to eq("/items/#{@pull_toy.id}")
+
+      visit "/merchant/orders/#{@order_1.id}"
+
+      expect(page).to have_link("#{@pull_toy.name}")
+      expect(page).to have_css("img[src*='#{@pull_toy.image}']")
+      expect(page).to have_content("#{@item_order_1.price}")
+      expect(page).to have_content("#{@item_order_1.quantity}")
+
+      expect(page).to have_link("#{@dog_bone.name}")
+      expect(page).to have_css("img[src*='#{@dog_bone.image}']")
+      expect(page).to have_content("#{@item_order_2.price}")
+      expect(page).to have_content("#{@item_order_2.quantity}")
+    end
   end
 end
-
-# User Story 49, Merchant sees an order show page
-
-# I do not see any items in the order being purchased from other merchants
-# For each item, I see the following information:
-# - the name of the item, which is a link to my item's show page
-# - an image of the item
-# - my price for the item
-# - the quantity the user wants to purchase

--- a/spec/features/merchant/orders/show_spec.rb
+++ b/spec/features/merchant/orders/show_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe 'merchant order show page' do
     it "shows all items in that order from the merchant if they are not fulfilled" do
 
       visit "/merchant/orders/#{@order_1.id}"
+
       click_on(id: "item_order-#{@item_order_1.id}")
 
       visit "/merchant/orders/#{@order_1.id}"
@@ -37,5 +38,26 @@ RSpec.describe 'merchant order show page' do
       expect(page).to have_content(@dog_bone.name)
       expect(page).to_not have_content(@pull_toy.name)
     end
+
+    it "shows the recipient's name and address used to create order" do
+
+      visit "/merchant/orders/#{@order_1.id}"
+
+      expect(page).to have_content(@kiera.name)
+      expect(page).to have_content(@kiera.address)
+      expect(page).to have_content(@kiera.city)
+      expect(page).to have_content(@kiera.state)
+      expect(page).to have_content(@kiera.zip)
+    end
   end
 end
+
+# User Story 49, Merchant sees an order show page
+
+# I only see the items in the order that are being purchased from my merchant
+# I do not see any items in the order being purchased from other merchants
+# For each item, I see the following information:
+# - the name of the item, which is a link to my item's show page
+# - an image of the item
+# - my price for the item
+# - the quantity the user wants to purchase

--- a/spec/features/merchant/orders/show_spec.rb
+++ b/spec/features/merchant/orders/show_spec.rb
@@ -3,20 +3,24 @@ require 'rails_helper'
 RSpec.describe 'merchant order show page' do
   describe 'As a merchant employee when I visit my merchant order show page (such as "/merchant/orders/15")' do
     before :each do
-      @bike_shop = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80210)
+      @dog_shop = Merchant.create!(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80210)
+      @bike_shop = Merchant.create!(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
 
-      @pull_toy = @bike_shop.items.create(name: "Pull Toy", description: "Great pull toy!", price: 10, image: "http://lovencaretoys.com/image/cache/dog/tug-toy-dog-pull-9010_2-800x800.jpg", inventory: 32)
-      @dog_bone = @bike_shop.items.create(name: "Dog Bone", description: "They'll love it!", price: 21, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", active?:false, inventory: 21)
+      @pull_toy = @dog_shop.items.create!(name: "Pull Toy", description: "Great pull toy!", price: 10, image: "http://lovencaretoys.com/image/cache/dog/tug-toy-dog-pull-9010_2-800x800.jpg", inventory: 32)
+      @dog_bone = @dog_shop.items.create!(name: "Dog Bone", description: "They'll love it!", price: 21, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", active?:false, inventory: 21)
+      @tire = @bike_shop.items.create!(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
 
       @kiera = User.create!(name: 'Kiera Allen', address: '124 Main St.', city: 'Denver', state: 'CO', zip: 80205, email: 'bobmarley.com', password: 'password')
+
       @order_1 = @kiera.orders.create!(name: 'Kiera Allen', address: '124 Main St.', city: 'Denver', state: 'CO', zip: 80205, user_id: @kiera.id)
       @order_2 = @kiera.orders.create!(name: 'Kiera Allen', address: '124 Main St.', city: 'Denver', state: 'CO', zip: 80205, user_id: @kiera.id)
 
       @item_order_1 = @order_1.item_orders.create!(item_id: @pull_toy.id, price: 4.50, quantity: 2)
       @item_order_2 = @order_1.item_orders.create!(item_id: @dog_bone.id, price: 7.00, quantity: 1)
       @item_order_3 = @order_2.item_orders.create!(item_id: @dog_bone.id, price: 7.00, quantity: 5)
+      @item_order_4 = @order_1.item_orders.create!(item_id: @tire.id, price: 8.00, quantity: 4)
 
-      @sally = User.create!(name: 'Sally Peach', address: '432 Grove St.', city: 'Denver', state: 'CO', zip: 80205, email: 'sallypeach.com', password: 'password', role: 1, merchant_id: @bike_shop.id)
+      @sally = User.create!(name: 'Sally Peach', address: '432 Grove St.', city: 'Denver', state: 'CO', zip: 80205, email: 'sallypeach.com', password: 'password', role: 1, merchant_id: @dog_shop.id)
 
       visit '/login'
 
@@ -49,12 +53,18 @@ RSpec.describe 'merchant order show page' do
       expect(page).to have_content(@kiera.state)
       expect(page).to have_content(@kiera.zip)
     end
+
+    it "only shows the items in the order purchased from my merchant" do
+
+      visit "/merchant/orders/#{@order_1.id}"
+
+      expect(page).to_not have_content(@tire.name)
+    end
   end
 end
 
 # User Story 49, Merchant sees an order show page
 
-# I only see the items in the order that are being purchased from my merchant
 # I do not see any items in the order being purchased from other merchants
 # For each item, I see the following information:
 # - the name of the item, which is a link to my item's show page

--- a/spec/features/merchant/orders/show_spec.rb
+++ b/spec/features/merchant/orders/show_spec.rb
@@ -69,15 +69,15 @@ RSpec.describe 'merchant order show page' do
 
       visit "/merchant/orders/#{@order_1.id}"
 
-      expect(page).to have_link("#{@pull_toy.name}")
+      expect(page).to have_link(@pull_toy.name)
       expect(page).to have_css("img[src*='#{@pull_toy.image}']")
-      expect(page).to have_content("#{@item_order_1.price}")
-      expect(page).to have_content("#{@item_order_1.quantity}")
+      expect(page).to have_content(@item_order_1.price)
+      expect(page).to have_content(@item_order_1.quantity)
 
-      expect(page).to have_link("#{@dog_bone.name}")
+      expect(page).to have_link(@dog_bone.name)
       expect(page).to have_css("img[src*='#{@dog_bone.image}']")
-      expect(page).to have_content("#{@item_order_2.price}")
-      expect(page).to have_content("#{@item_order_2.quantity}")
+      expect(page).to have_content(@item_order_2.price)
+      expect(page).to have_content(@item_order_2.quantity)
     end
   end
 end


### PR DESCRIPTION
This PR:

- makes the recipient's name and address (that was used to create this order) visible on the `merchant/order/show.html.erb`
- only see items purchased from my merchant and no others
- For each item, I see the name of the item (which is a link to my item's show page), an image of the item, my price for the item, the quantity the user wants to purchase

- closes #49 