### PR TITLE
Admin user profiles

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -4,6 +4,6 @@ class Admin::UsersController < Admin::BaseController
   end
 
   def show
-
+    @user = User.find(params[:user_id])
   end
 end

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,10 +1,3 @@
 <%= content_tag :h1, "Welcome #{@user.name}!!!" %>
 
-<body class="profile-body">
-  <%= content_tag :h3, "Address:" %>
-  <%= content_tag :p, "#{@user.address}"%>
-  <%= content_tag :p, "#{@user.city}, #{@user.state}" %>
-  <%= content_tag :p, "#{@user.zip}" %>
-  <%= content_tag :h3, "Email:" %>
-  <%= content_tag :h3, "#{@user.email}" %>
-</body>
+<%= render partial: "/partials/users/profile_body", locals: {user: @user} %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,0 +1,10 @@
+<%= content_tag :h1, "Welcome #{@user.name}!!!" %>
+
+<body class="profile-body">
+  <%= content_tag :h3, "Address:" %>
+  <%= content_tag :p, "#{@user.address}"%>
+  <%= content_tag :p, "#{@user.city}, #{@user.state}" %>
+  <%= content_tag :p, "#{@user.zip}" %>
+  <%= content_tag :h3, "Email:" %>
+  <%= content_tag :h3, "#{@user.email}" %>
+</body>

--- a/app/views/partials/users/_profile_body.html.erb
+++ b/app/views/partials/users/_profile_body.html.erb
@@ -1,0 +1,13 @@
+<%= content_tag :body, class: "profile-body" do %>
+  <%= content_tag :h3, "Address:" %>
+  <%= content_tag :p, "#{user.address}"%>
+  <%= content_tag :p, "#{user.city}, #{user.state}" %>
+  <%= content_tag :p, "#{user.zip}" %>
+  <%= content_tag :h3, "Email:" %>
+  <%= content_tag :h3, "#{user.email}" %>
+
+  <% if !(current_admin?) %>
+    <%= link_to "Edit Profile", "/profile/edit"%>
+    <%= link_to "Edit Password", "/profile/edit/password"%>
+  <% end %>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -4,14 +4,4 @@
   <ul><%= link_to "My Orders", "/profile/orders" %></ul>
 <% end %>
 
-<body class="profile-body">
-  <%= content_tag :h3, "Address:" %>
-  <%= content_tag :p, "#{@user.address}"%>
-  <%= content_tag :p, "#{@user.city}, #{@user.state}" %>
-  <%= content_tag :p, "#{@user.zip}" %>
-  <%= content_tag :h3, "Email:" %>
-  <%= content_tag :h3, "#{@user.email}" %>
-
-  <%= link_to "Edit Profile", "/profile/edit"%>
-  <%= link_to "Edit Password", "/profile/edit/password"%>
-</body>
+<%= render partial: "/partials/users/profile_body", locals: {user: @user} %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,7 +74,7 @@ Rails.application.routes.draw do
   namespace :admin do
     get "/", to: "dashboard#index"
     get "/users", to: "users#index"
-    get "/users/:id", to: "users#show"
+    get "/users/:user_id", to: "users#show"
     get "/merchants", to: "merchants#index"
     get "/merchants/:id", to: "merchants#show"
     patch "/merchants/:merchant_id/disable", to: "merchants#disable"

--- a/spec/features/admin/users/show_spec.rb
+++ b/spec/features/admin/users/show_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe "Admin User Index Page:" do
+  before :each do
+    @user = User.create!(name: 'Kiera Allen', address: '124 Main St.', city: 'Denver', state: 'CO', zip: 80205, email: 'bob@marley.com', password: 'password', role: 0)
+    merchant = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80210)
+    @merchant_user = User.create!(name: 'Sally Peach', address: '432 Grove St.', city: 'Denver', state: 'CO', zip: 80205, email: 'sally@peach.com', password: 'password', role: 1, merchant_id: merchant.id)
+    @admin = User.create!(name: 'Bob Ross', address: '745 Rose St.', city: 'Denver', state: 'CO', zip: 80205, email: 'bob@ross.com', password: 'password', role: 2)
+  end
+
+  describe "As an admin user," do
+    before :each do
+      visit '/login'
+
+      fill_in :email, with: @admin.email
+      fill_in :password, with: @admin.password
+
+      click_button 'Login'
+    end
+    describe "when I visit a user's profile page ('admin/users/:user_id')" do
+      it "I see the same info the user would see themselves, excluding the link to edit their profile" do
+
+        visit "/admin/users/#{@user.id}"
+
+        expect(page).to have_content(@user.name)
+        expect(page).to have_content(@user.address)
+        expect(page).to have_content(@user.city)
+        expect(page).to have_content(@user.state)
+        expect(page).to have_content(@user.zip)
+        expect(page).to have_content(@user.email)
+        expect(page).to_not have_link("Edit Profile")
+        expect(page).to_not have_link("Edit Password")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds admin-accessible user profile views.
---
- DRYs out user profile pages through partials
- Adds logic to prevent admin from editing user profile info or password
- All tests passing
- Closes #54 